### PR TITLE
Fixing the passwd issue reported internally in INF-408

### DIFF
--- a/files/etc/pam.d/system-auth-ac
+++ b/files/etc/pam.d/system-auth-ac
@@ -1,0 +1,21 @@
+#%PAM-1.0
+# This file is maintained in Puppet
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 500 quiet_success
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so

--- a/files/etc/security/pwquality.conf
+++ b/files/etc/security/pwquality.conf
@@ -1,0 +1,50 @@
+# Configuration for systemwide password quality limits
+# This file is maintained in Puppet
+#
+# Number of characters in the new password that must not be present in the
+# old password.
+difok = 4
+#
+# Minimum acceptable size for the new password (plus one if
+# credits are not disabled which is the default). (See pam_cracklib manual.)
+# Cannot be set to lower value than 6.
+minlen = 10
+#
+# The maximum credit for having digits in the new password. If less than 0
+# it is the minimum number of digits in the new password.
+dcredit = -1
+#
+# The maximum credit for having uppercase characters in the new password.
+# If less than 0 it is the minimum number of uppercase characters in the new
+# password.
+ucredit = -1
+#
+# The maximum credit for having lowercase characters in the new password.
+# If less than 0 it is the minimum number of lowercase characters in the new
+# password.
+lcredit = 0
+#
+# The maximum credit for having other characters in the new password.
+# If less than 0 it is the minimum number of other characters in the new
+# password.
+ocredit = -1
+#
+# The minimum number of required classes of characters for the new
+# password (digits, uppercase, lowercase, others).
+# minclass = 0
+#
+# The maximum number of allowed consecutive same characters in the new password.
+# The check is disabled if the value is 0.
+# maxrepeat = 0
+#
+# The maximum number of allowed consecutive characters of the same class in the
+# new password.
+# The check is disabled if the value is 0.
+# maxclassrepeat = 0
+#
+# Whether to check for the words from the passwd entry GECOS string of the user.
+# The check is enabled if the value is not 0.
+# gecoscheck = 0
+#
+# Path to the cracklib dictionaries. Default is to use the cracklib default.
+# dictpath =

--- a/manifests/linuxcontrols/c0071.pp
+++ b/manifests/linuxcontrols/c0071.pp
@@ -11,7 +11,13 @@ class cis::linuxcontrols::c0071 {
     target  => '/etc/pam.d/system-auth-ac',
   }
   file {'/etc/pam.d/system-auth-ac':
-    source  => 'puppet:///modules/cis/el6/etc/pam.d/system-auth-ac',
+    source  => 'puppet:///modules/cis/el7/etc/pam.d/system-auth-ac',
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+  }
+  file {'/etc/security/pwquality.conf':
+    source  => 'puppet:///modules/cis/el7/etc/security/pwquality.conf',
     owner   => root,
     group   => root,
     mode    => '0644',


### PR DESCRIPTION
pam_passwdqc.so has been deprecated in favor of pam_pwquality.so on el7. This change keeps the spirit of the linuxcontrols/c0071.pp in place while actually functioning on el7.

Before merging this you'd get "passwd: Module is unknown" when attempting to change your password on an el7 host with this module applied.
